### PR TITLE
replaced rhash with sha512sum because sha512sum is preinstalled on ma…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ You can create one with `openssl rand 256 > key`. Save it also securely on your 
 ```
 #!/bin/bash
 cd /home/user/configfiles
+sha512sum files.tar > files.tar.sha512
 ./encrypt.sh
-if [[ $(git status -s) == *"files.tar.sha3-512" ]]; then
+sha512sum -c files.tar.sha512
+if [ $? -eq 1] > /dev/null
+then
     git add *
     git commit -m "new config files"
     git push

--- a/encrypt.sh
+++ b/encrypt.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 tar -chf files.tar files
-rhash --sha3-512 files.tar > files.tar.sha3-512
 openssl aes-256-cbc -e -in files.tar -out files.tar.enc -pass file:key
-rhash --sha3-512 files.tar.enc > files.tar.enc.sha3-512


### PR DESCRIPTION
…ny systems while rhash needs to be installed

made the cron script better readable by "repalcing git status -s ..." by using sha512sum -c to check if config files have changed